### PR TITLE
Use typescript classes

### DIFF
--- a/src/mock/MockBuilder.spec.ts
+++ b/src/mock/MockBuilder.spec.ts
@@ -3,6 +3,7 @@ import {MockBuilder} from "./MockBuilder";
 import {Mock} from "./Mock";
 import Spy = jasmine.Spy;
 import {ConstructorArguments} from "./ConstructorArguments";
+import {IConstructor} from "./IConstructor";
 
 interface IFoo {
     stringVal: string;
@@ -117,10 +118,10 @@ describe("MockBuilder", () => {
         constructorArguments = new ConstructorArguments()
             .map("stringVal", "just a str")
             .map("booleanVal", true)
-            .map("barVal", new Bar())
-        mock = MockBuilder.createInstance<IFoo>(Foo, constructorArguments);
-        inheritedMock = MockBuilder.createInstance<IFoo>(Baz, constructorArguments);
-        mockWithoutArguments = MockBuilder.createInstance<INoConstructor>(NoConstructor);
+            .map("barVal", new Bar());
+        mock = MockBuilder.createInstance<IFoo>(<IConstructor<Foo>>Foo, constructorArguments);
+        inheritedMock = MockBuilder.createInstance<IFoo>(<IConstructor<Baz>>Baz, constructorArguments);
+        mockWithoutArguments = MockBuilder.createInstance<INoConstructor>(<IConstructor<NoConstructor>>NoConstructor);
     });
 
     describe("for normal objects", () => {
@@ -191,7 +192,7 @@ describe("MockBuilder", () => {
                         .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
-            })
+            });
             describe("on getSpy()", () => {
                 it("should return the spy of the method", () => {
                     var spy: Spy = mock
@@ -270,7 +271,7 @@ describe("MockBuilder", () => {
                         .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
-            })
+            });
             describe("on getSpy()", () => {
                 it("should return the spy of the method", () => {
                     var spy: Spy = inheritedMock
@@ -347,7 +348,7 @@ describe("MockBuilder", () => {
                         .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
-            })
+            });
             describe("on getSpy()", () => {
                 it("should return the spy of the method", () => {
                     var spy: Spy = mockWithoutArguments

--- a/src/mock/MockBuilder.spec.ts
+++ b/src/mock/MockBuilder.spec.ts
@@ -1,9 +1,7 @@
 // these are the testinterfaces and testclasses we will use to test our mock functionality
-import {MockBuilder} from "./MockBuilder";
 import {Mock} from "./Mock";
 import Spy = jasmine.Spy;
 import {ConstructorArguments} from "./ConstructorArguments";
-import {IConstructor} from "./IConstructor";
 import {MockBuilder} from "./MockBuilder";
 import INoConstructor from "./";
 
@@ -121,9 +119,9 @@ describe("MockBuilder", () => {
             .map("stringVal", "just a str")
             .map("booleanVal", true)
             .map("barVal", new Bar());
-        mock = MockBuilder.createInstance<IFoo>(<IConstructor<Foo>>Foo, constructorArguments);
-        inheritedMock = MockBuilder.createInstance<IFoo>(<IConstructor<Baz>>Baz, constructorArguments);
-        mockWithoutArguments = MockBuilder.createInstance<INoConstructor>(<IConstructor<NoConstructor>>NoConstructor);
+        mock = MockBuilder.createInstance<IFoo>(Foo, constructorArguments);
+        inheritedMock = MockBuilder.createInstance<IFoo>(Baz, constructorArguments);
+        mockWithoutArguments = MockBuilder.createInstance<INoConstructor>(NoConstructor);
     });
 
     describe("for normal objects", () => {
@@ -368,9 +366,7 @@ describe("MockBuilder: original context sanity check", () => {
         const bar1: Bar = new Bar();
         expect(bar1.bar()).toBe("just a string");
 
-        const barMock: Mock<IBar> = MockBuilder
-            .createInstance(<IConstructor<IBar>>Bar);
-
+        const barMock: Mock<IBar> = MockBuilder.createInstance<IBar>(Bar);
         expect(barMock.instance.bar()).toBe(undefined);
 
         const bar2: Bar = new Bar();
@@ -382,7 +378,7 @@ describe("MockBuilder: original context sanity check", () => {
         expect(bar1.bar()).toBe("just a string");
 
         const barMock: Mock<IBar> = MockBuilder
-            .createInstance(<IConstructor<IBar>>Bar)
+            .createInstance<IBar>(Bar)
             .setupMethod("bar").andReturn("spied!");
 
         expect(barMock.instance.bar()).toBe("spied!");

--- a/src/mock/MockBuilder.spec.ts
+++ b/src/mock/MockBuilder.spec.ts
@@ -4,6 +4,8 @@ import {Mock} from "./Mock";
 import Spy = jasmine.Spy;
 import {ConstructorArguments} from "./ConstructorArguments";
 import {IConstructor} from "./IConstructor";
+import {MockBuilder} from "./MockBuilder";
+import INoConstructor from "./";
 
 interface IFoo {
     stringVal: string;
@@ -187,9 +189,9 @@ describe("MockBuilder", () => {
                 });
                 it("should return the mock object", () => {
                     var returnObj: any = mock.setupMethod("bar")
-                        .andReturn("dummyValue")
-                        .setupMethod("baz")
-                        .andReturn(100);
+                                             .andReturn("dummyValue")
+                                             .setupMethod("baz")
+                                             .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
             });
@@ -242,9 +244,9 @@ describe("MockBuilder", () => {
             it("should map the property on the stubbed object", () => {
                 var barVal: IBar = new Bar();
                 inheritedMock.mapProperty("numberVal", 100)
-                    .mapProperty("booleanVal", true)
-                    .mapProperty("stringVal", "dummystr")
-                    .mapProperty("barVal", barVal);
+                             .mapProperty("booleanVal", true)
+                             .mapProperty("stringVal", "dummystr")
+                             .mapProperty("barVal", barVal);
                 expect(inheritedMock.instance.numberVal).toBe(100);
                 expect(inheritedMock.instance.booleanVal).toBe(true);
                 expect(inheritedMock.instance.stringVal).toBe("dummystr");
@@ -258,17 +260,17 @@ describe("MockBuilder", () => {
             describe("on andReturn() on the stubbedFunc method", () => {
                 it("should cast the function to a spy and map the passed return value on it", () => {
                     inheritedMock.setupMethod("bar")
-                        .andReturn("dummyValue")
-                        .setupMethod("baz")
-                        .andReturn(100);
+                                 .andReturn("dummyValue")
+                                 .setupMethod("baz")
+                                 .andReturn(100);
                     expect(inheritedMock.instance.bar()).toBe("dummyValue");
                     expect(inheritedMock.instance.baz()).toBe(100);
                 });
                 it("should return the mock object", () => {
                     var returnObj: any = inheritedMock.setupMethod("bar")
-                        .andReturn("dummyValue")
-                        .setupMethod("baz")
-                        .andReturn(100);
+                                                      .andReturn("dummyValue")
+                                                      .setupMethod("baz")
+                                                      .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
             });
@@ -320,9 +322,9 @@ describe("MockBuilder", () => {
             it("should map the property on the stubbed object", () => {
                 var barVal: IBar = new Bar();
                 mockWithoutArguments.mapProperty("numberVal", 100)
-                    .mapProperty("booleanVal", true)
-                    .mapProperty("stringVal", "dummystr")
-                    .mapProperty("barVal", barVal);
+                                    .mapProperty("booleanVal", true)
+                                    .mapProperty("stringVal", "dummystr")
+                                    .mapProperty("barVal", barVal);
                 expect(mockWithoutArguments.instance.numberVal).toBe(100);
                 expect(mockWithoutArguments.instance.booleanVal).toBe(true);
                 expect(mockWithoutArguments.instance.stringVal).toBe("dummystr");
@@ -335,17 +337,17 @@ describe("MockBuilder", () => {
             describe("on andReturn() on the stubbedFunc method", () => {
                 it("should cast the function to a spy and map the passed return value on it", () => {
                     mockWithoutArguments.setupMethod("bar")
-                        .andReturn("dummyValue")
-                        .setupMethod("baz")
-                        .andReturn(100);
+                                        .andReturn("dummyValue")
+                                        .setupMethod("baz")
+                                        .andReturn(100);
                     expect(mockWithoutArguments.instance.bar()).toBe("dummyValue");
                     expect(mockWithoutArguments.instance.baz()).toBe(100);
                 });
                 it("should return the mock object", () => {
                     var returnObj: any = mockWithoutArguments.setupMethod("bar")
-                        .andReturn("dummyValue")
-                        .setupMethod("baz")
-                        .andReturn(100);
+                                                             .andReturn("dummyValue")
+                                                             .setupMethod("baz")
+                                                             .andReturn(100);
                     expect(returnObj.hasOwnProperty("instance")).toBe(true);
                 });
             });
@@ -358,5 +360,34 @@ describe("MockBuilder", () => {
                 });
             });
         });
+    });
+});
+
+describe("MockBuilder: original context sanity check", () => {
+    it("can create a mock", () => {
+        const bar1: Bar = new Bar();
+        expect(bar1.bar()).toBe("just a string");
+
+        const barMock: Mock<IBar> = MockBuilder
+            .createInstance(<IConstructor<IBar>>Bar);
+
+        expect(barMock.instance.bar()).toBe(undefined);
+
+        const bar2: Bar = new Bar();
+        expect(bar2.bar()).toBe("just a string");
+    });
+
+    it("can create a mock with a spied method", () => {
+        const bar1: Bar = new Bar();
+        expect(bar1.bar()).toBe("just a string");
+
+        const barMock: Mock<IBar> = MockBuilder
+            .createInstance(<IConstructor<IBar>>Bar)
+            .setupMethod("bar").andReturn("spied!");
+
+        expect(barMock.instance.bar()).toBe("spied!");
+
+        const bar2: Bar = new Bar();
+        expect(bar2.bar()).toBe("just a string");
     });
 });

--- a/src/mock/MockBuilder.ts
+++ b/src/mock/MockBuilder.ts
@@ -8,7 +8,9 @@ export class MockBuilder {
         var instance: T = (() => {
             var ConstructFunc: any = () => {
             };
-            ConstructFunc.prototype = ctor.prototype;
+            ConstructFunc.prototype = Object.create(ctor.prototype);
+            ConstructFunc.prototype.constructor = ConstructFunc;
+
             for (var i in ConstructFunc.prototype) {
                 ConstructFunc.prototype[i] = jasmine.createSpy(ConstructFunc.prototype[i]);
             }
@@ -19,7 +21,7 @@ export class MockBuilder {
             } else {
                 ctor.apply(inst, []);
             }
-            this.setDefaultVals(inst, args);
+            MockBuilder.setDefaultVals(inst, args);
             return inst;
         })();
         return new Mock<T>(instance, args);


### PR DESCRIPTION
refactored the MockBuilder to use typescript classes instead of native JS prototype inheritance
