### PR TITLE
Removed postinstall to copy definition files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
     "prebuild": "tsd install && rm -rf dist && mkdir dist",
     "build": "tsc",
     "postbuild": "npm run dts-bundle",
-    "prepublish": "npm run build",
-    "postinstall": "node tasks/create-typings-folder && cp dist/typescript-mockify.d.ts ../../typings/typescript-mockify.d.ts"
+    "prepublish": "npm run build"    
   },
   "typescript": {
     "definition": "dist/typescript-mockify.d.ts"

--- a/tasks/create-typings-folder.js
+++ b/tasks/create-typings-folder.js
@@ -1,2 +1,0 @@
-var mkdir = require('safe-mkdir').mkdir;
-mkdir('../../typings');


### PR DESCRIPTION
Since tsd and typings can link to the correct d.ts it's up to the application to link the d.ts files
